### PR TITLE
Remove duplicated "how to setup/install" section

### DIFF
--- a/content/essential-knowledge/how-to-contribute-code.md
+++ b/content/essential-knowledge/how-to-contribute-code.md
@@ -38,38 +38,3 @@ TODO:
 More advanced:
 * Code review (?)
 * Setting up dev environment
-
----
-title : How to set up git on your local machine
----
-
-# Linux
-For Debian based systems
-
-```sudo apt-get update
-sudo apt-get upgrade
-sudo apt-get install git
-```
-
-For Red Hat based systems
-
-```sudo yum upgrade
-sudo yum install git
-```
-
-
-# Mac
-Open terminal and type the following 
-```ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-brew doctor
-brew install git
-```
-
-
-# Windows 
-We recommend getting GitKraken from [download page](https://www.gitkraken.com/), run the 
-.exe (can someone else fill this in please)
-
-
-# SourceBots Volunteer Documentation
-This documentation contains information about how to setup github on your local machine 


### PR DESCRIPTION
I think all of this information should go in the part above.
Installation is covered by https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
IDEs and things like GitKraken are mentioned elsewhere.